### PR TITLE
[1.13] Backport CVE-2025-48883: [1.14] Security fix for missing encoding in `CssSelector` (#691)

### DIFF
--- a/src/Dom/Selector/CssSelector.php
+++ b/src/Dom/Selector/CssSelector.php
@@ -10,20 +10,32 @@ namespace HeadlessChromium\Dom\Selector;
 final class CssSelector implements Selector
 {
     /** @var string */
-    private $expression;
+    private $expressionEncoded;
 
     public function __construct(string $expression)
     {
-        $this->expression = $expression;
+        $this->expressionEncoded = \json_encode(
+            $expression,
+            \JSON_UNESCAPED_SLASHES
+                | \JSON_UNESCAPED_UNICODE
+                | \JSON_THROW_ON_ERROR
+        );
     }
 
     public function expressionCount(): string
     {
-        return \sprintf('document.querySelectorAll("%s").length', $this->expression);
+        return \sprintf(
+            'document.querySelectorAll(%s).length',
+            $this->expressionEncoded
+        );
     }
 
     public function expressionFindOne(int $position): string
     {
-        return \sprintf('document.querySelectorAll("%s")[%d]', $this->expression, $position - 1);
+        return \sprintf(
+            'document.querySelectorAll(%s)[%d]',
+            $this->expressionEncoded,
+            $position - 1
+        );
     }
 }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -21,7 +21,7 @@ use HeadlessChromium\Exception\InvalidTimezoneId;
  */
 class PageTest extends BaseTestCase
 {
-    private const WAIT_FOR_ELEMENT_HTML = '<div data-name="el">content</div>';
+    private const WAIT_FOR_ELEMENT_HTML = '<div data-name="el">content1</div><div data-name="&quot;el&quot;">content2</div>';
     private const WAIT_FOR_ELEMENT_RESOURCE_FILE = 'elementLoad.html';
 
     public function testSetViewport(): void
@@ -441,7 +441,9 @@ class PageTest extends BaseTestCase
 
         self::assertStringNotContainsString(self::WAIT_FOR_ELEMENT_HTML, $page->getHtml());
 
-        $page->waitUntilContainsElement('div[data-name=\"el\"]');
+        $page->waitUntilContainsElement('div[data-name="el"]'); // search for <div data-name="el">
+        $page->waitUntilContainsElement('div[data-name=el]'); // search for <div data-name="el">
+        $page->waitUntilContainsElement('div[data-name=\"el\"]'); // search for <div data-name="&quot;el&quot;'>
 
         self::assertStringContainsString(self::WAIT_FOR_ELEMENT_HTML, $page->getHtml());
     }

--- a/tests/resources/static-web/elementLoad.html
+++ b/tests/resources/static-web/elementLoad.html
@@ -11,9 +11,15 @@
       let el = document.createElement('div');
 
       el.dataset.name = 'el';
-      el.innerHTML = 'content';
+      el.innerHTML = 'content1';
 
       document.body.appendChild(el)
+
+      let el2 = document.createElement('div');
+
+      el2.dataset.name = '"el"';
+      el2.innerHTML = 'content2';
+      document.body.appendChild(el2)
     }, 500)
 </script>
 </html>


### PR DESCRIPTION
Backport of upstream fix for CVE-2025-48883 to `1.13`.

- Upstream commit: [34b2b8d169](https://github.com/chrome-php/chrome/commit/34b2b8d1691f4e3940b1e1e95d388fffe81169c8) — [1.14] Security fix for missing encoding in `CssSelector` (#691)
- Cherry-picked with `git cherry-pick -x` (original author preserved).

Apply was clean against the current tip of the target branch. No code changes on top of the upstream fix.